### PR TITLE
Added `ignore_zero` param to `clr`

### DIFF
--- a/composition_stats/__init__.py
+++ b/composition_stats/__init__.py
@@ -471,7 +471,7 @@ def clr(mat, ignore_zero=False):
         msk = mat.astype(bool)
         lmat = np.log(mat, where=msk)
         gm = lmat.mean(axis=-1, keepdims=True, where=msk)
-        return np.where(msk, (lmat - gm).squeeze(), lmat)
+        return np.where(msk, (lmat - gm).squeeze(), 0.)
     else:
         lmat = np.log(mat)
         gm = lmat.mean(axis=-1, keepdims=True)

--- a/composition_stats/__init__.py
+++ b/composition_stats/__init__.py
@@ -421,7 +421,7 @@ def inner(x, y):
     return a.dot(b.T)
 
 
-def clr(mat):
+def clr(mat, ignore_zero=False):
     r"""
     Performs centre log ratio transformation.
 
@@ -449,6 +449,9 @@ def clr(mat):
        rows = compositions and
        columns = components
        each composition (row) must add up to unity (see :ref:`closure()`)
+    ignore_zero : bool
+        whether to ignore zeros in ``mat``. This reproduces the behavior of the
+        ``compositions`` R package.
 
     Returns
     -------
@@ -464,9 +467,15 @@ def clr(mat):
     array([-0.79451346,  0.30409883,  0.5917809 , -0.10136628])
 
     """
-    lmat = np.log(mat)
-    gm = lmat.mean(axis=-1, keepdims=True)
-    return (lmat - gm).squeeze()
+    if ignore_zero:
+        msk = mat.astype(bool)
+        lmat = np.log(mat, where=msk)
+        gm = lmat.mean(axis=-1, keepdims=True, where=msk)
+        return np.where(msk, (lmat - gm).squeeze(), lmat)
+    else:
+        lmat = np.log(mat)
+        gm = lmat.mean(axis=-1, keepdims=True)
+        return (lmat - gm).squeeze()
 
 
 def clr_inv(mat):

--- a/composition_stats/__init__.py
+++ b/composition_stats/__init__.py
@@ -449,9 +449,8 @@ def clr(mat, ignore_zero=False):
        rows = compositions and
        columns = components
        each composition (row) must add up to unity (see :ref:`closure()`)
-    ignore_zero : bool
-        whether to ignore zeros in ``mat``. This reproduces the behavior of the
-        ``compositions`` R package.
+    ignore_zero : bool, optional
+       whether to ignore zeros in ``mat`` (default: false)
 
     Returns
     -------

--- a/composition_stats/__init__.py
+++ b/composition_stats/__init__.py
@@ -467,14 +467,14 @@ def clr(mat, ignore_zero=False):
 
     """
     if ignore_zero:
-        msk = mat.astype(bool)
-        lmat = np.log(mat, where=msk)
-        gm = lmat.mean(axis=-1, keepdims=True, where=msk)
-        return np.where(msk, (lmat - gm).squeeze(), 0.)
+        where = (mat != 0)
+        out = np.zeros_like(mat, dtype=float)
     else:
-        lmat = np.log(mat)
-        gm = lmat.mean(axis=-1, keepdims=True)
-        return (lmat - gm).squeeze()
+        where = True
+        out = None
+    lmat = np.log(mat, where=where, out=out)
+    gm = lmat.mean(axis=-1, keepdims=True, where=where)
+    return np.subtract(lmat, gm, where=where, out=lmat).squeeze()
 
 
 def clr_inv(mat):

--- a/composition_stats/tests/test_composition.py
+++ b/composition_stats/tests/test_composition.py
@@ -232,7 +232,8 @@ class CompositionTests(TestCase):
         npt.assert_allclose(self.cdata2, np.array([2, 2, 6]))
 
         # test ignore_zero
-        with self.assertWarnsRegex(RuntimeWarning, 'divide by zero encountered'):
+        msg = 'divide by zero encountered'
+        with self.assertWarnsRegex(RuntimeWarning, msg):
             cmat = clr(closure(self.cdata3), ignore_zero=False)
             assert not np.all(np.isfinite(cmat))
         cmat = clr(closure(self.cdata3), ignore_zero=True)

--- a/composition_stats/tests/test_composition.py
+++ b/composition_stats/tests/test_composition.py
@@ -234,7 +234,7 @@ class CompositionTests(TestCase):
         # test ignore_zero
         with self.assertWarnsRegex(RuntimeWarning, 'divide by zero encountered'):
             cmat = clr(closure(self.cdata3), ignore_zero=False)
-            assert np.any(np.isfinite(cmat))
+            assert not np.all(np.isfinite(cmat))
         cmat = clr(closure(self.cdata3), ignore_zero=True)
         assert np.all(np.isfinite(cmat))
         npt.assert_allclose(cmat[0, 0], -0.85029934)

--- a/composition_stats/tests/test_composition.py
+++ b/composition_stats/tests/test_composition.py
@@ -231,6 +231,14 @@ class CompositionTests(TestCase):
         clr(closure(self.cdata2))
         npt.assert_allclose(self.cdata2, np.array([2, 2, 6]))
 
+        # test ignore_zero
+        with self.assertWarnsRegex(RuntimeWarning, 'divide by zero encountered'):
+            cmat = clr(closure(self.cdata3), ignore_zero=False)
+            assert np.any(np.isfinite(cmat))
+        cmat = clr(closure(self.cdata3), ignore_zero=True)
+        assert np.all(np.isfinite(cmat))
+        npt.assert_allclose(cmat[0, 0], -0.85029934)
+
     def test_clr_inv(self):
         npt.assert_allclose(clr_inv(self.rdata1), self.ortho1)
         npt.assert_array_almost_equal(clr(clr_inv(self.rdata1)), self.rdata1)


### PR DESCRIPTION
Added `ignore_zero` param to `clr` to reproduce the results of `compositions` R package according to the discussion in https://github.com/ntessore/composition_stats/issues/2. I also added some tests for it.
Please feel free to modify/update this PR as you wish.